### PR TITLE
Fix type error

### DIFF
--- a/consonance/handshake.py
+++ b/consonance/handshake.py
@@ -282,7 +282,7 @@ class WAHandshake(object):
         client_payload.passive = client_config.passive
         client_payload.push_name = client_config.pushname
 
-        max_int = (2**32) / 2
+        max_int = 2**31
 
         client_payload.session_id = random.randint(-max_int, max_int-1)
         client_payload.short_connect = client_config.short_connect


### PR DESCRIPTION
fixes this issue on python3.12

```
___________________ HandshakesTest.test_xx_handshake_offline ___________________

self = <tests.test_handshakes_offline.HandshakesTest testMethod=test_xx_handshake_offline>

    def test_xx_handshake_offline(self):
        stream = DummySegmentedStream([
            base64.b64decode(
                b"GvoBCiCiMwovEL8pYkUdcxCz6w5lvzvyxgAgHiNm4LnOwO8KQxIwt+dvmTcTMcE12jCC"
                b"rbnLcFY+H2/QuKr4/h4BCHy0rDS9rKp63yqRfFX5vEPY0/UGGqMBCfYtpYzsdsU3cN0Bq4ui5Dm0MY/+Yur2cCFb"
                b"tLRgBa858hWFuCIuWKrkE89GrF0uo+wJsolq4miiqMOdXJfuZ2YBZ4paFS2mWjVmQSINRo8J3LzXncUDMeQBO/KkC"
                b"ARw5BTcVkj2gwI6FG+yB/qI8BUJIxxswJc6q+H+HWkNro+Xl6urn5aOwK7bgBSPNctncZGY72NlJByEQCB6Bra7U"
                b"ykzQA==")
        ])
        ephemeral = KeyPair.from_bytes(
            base64.b64decode(
                b"qLt+l8Jh9mUF/QciIRjd7Z0qKyhN//46Xawk5jdL4WF4tFaszfGgyodH3ErvqU5lV4GnOccdy9zj39GU6AAPVQ=="
            )
        )
        # initialize WANoiseProtocol 2.1
        wa_handshake = WAHandshake(2, 1)
        # this should do a XX handshake since we are not passing the remote static public key
>       wa_handshake.perform(self.CONFIG, stream, self.KEYPAIR, e=ephemeral)

tests/test_handshakes_offline.py:47: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
consonance/handshake.py:79: in perform
    client_payload = self._create_full_payload(client_config)
consonance/handshake.py:287: in _create_full_payload
    client_payload.session_id = random.randint(-max_int, max_int-1)
/nix/store/7yh2ax34jd7fgf17mjfd3c6niw1h2hsj-python3-3.12.2/lib/python3.12/random.py:336: in randint
    return self.randrange(a, b+1)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <random.Random object at 0x65cce0>, start = -2147483648.0
stop = 2147483648.0, step = 1

    def randrange(self, start, stop=None, step=_ONE):
        """Choose a random item from range(stop) or range(start, stop[, step]).
    
        Roughly equivalent to ``choice(range(start, stop, step))`` but
        supports arbitrarily large ranges and is optimized for common cases.
    
        """
    
        # This code is a bit messy to make it fast for the
        # common case while still doing adequate error checking.
>       istart = _index(start)
E       TypeError: 'float' object cannot be interpreted as an integer
```